### PR TITLE
refactor: context.read -> Provider.of

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,7 +13,7 @@ void main() => runApp(
         providers: [
           Provider(create: (_) => SecureRepository()),
           StateNotifierProvider<SplashController, SplashState>(
-              create: (context) => SplashController(context)),
+              create: (context) => SplashController()),
           StateNotifierProvider<LoginController, LoginState>(
               create: (_) => LoginController()),
         ],

--- a/lib/ui/splash/splash_controller.dart
+++ b/lib/ui/splash/splash_controller.dart
@@ -4,11 +4,14 @@ import 'package:state_notifier_example/domain/repository/secure_repository.dart'
 import 'package:state_notifier_example/ui/splash/splash_state.dart';
 
 class SplashController extends StateNotifier<SplashState> with LocatorMixin {
-  SplashController(this.context) : super(const SplashState());
-
-  final BuildContext context;
+  SplashController() : super(const SplashState());
 
   SecureRepository get secureRepository => read<SecureRepository>();
+
+  Future<bool> handleInit() async {
+    await Future<void>.delayed(const Duration(seconds: 3));
+    return isLoggedIn();
+  }
 
   Future<bool> isLoggedIn() async {
     final accessToken =

--- a/lib/ui/splash/splash_page.dart
+++ b/lib/ui/splash/splash_page.dart
@@ -3,14 +3,15 @@ import 'package:provider/provider.dart';
 import 'package:state_notifier_example/ui/splash/splash_controller.dart';
 
 class SplashPage extends StatelessWidget {
+  Future<void> _onInit(BuildContext context) async {
+    final controller = Provider.of<SplashController>(context, listen: false);
+    final isLogin = await controller.handleInit();
+    await Navigator.of(context).pushReplacementNamed(isLogin ? '/contents' : '/login');
+  }
+
   @override
   Widget build(BuildContext context) {
-    Future<dynamic>.delayed(const Duration(seconds: 3)).then((dynamic value) {
-      context.read<SplashController>().isLoggedIn().then((value) {
-        Navigator.of(context).pushReplacementNamed(value ? "/contents" : "/login");
-      });
-    });
-
+    _onInit(context);
     return const Scaffold(
       body: Center(
         child: Text('Splash'),


### PR DESCRIPTION
私の結論

`context.read`の代わりに`Provider.of`つかえばいい気がする

前提

* SplashPage.build が複数回呼ばれない前提とする
  - よばれる場合はなんどもNavigatorへの操作が発生する
  -> 回避するには SplashControllerでhandleInitの呼び出し時に実行済みか確認する
  -> このばあいisLoginはstateを使う必要がありそう(splashが終了しているかの判定も必要そう)

理由

* buildメソッドの呼び出しでcontext.read をすること自体がよくない
* ではどこでよびだすべきか?
  -> StatefullWidgetの `didChangeDependencies` あたりがよさそうだがStaelessWidgetでは該当するところがない
* では代わりにどうするか?
  -> context.readの実装は Provider.of(listen: false)なのでこれを直接よべばよい
  -> https://github.com/rrousselGit/provider/blob/master/lib/src/provider.dart#L531-L544
* よんでよいのか?
  -> context.readの用途としてコールバック内で呼び出すことを想定している。問題の認識をしていれば問題ないだろう

そのた気になること

* Splashの表示をし終わった後の繊維先はSplashの責務ではないので、遷移先はDIするなに、子のWidgetに任せる感じが良さそう
* それはさておいて、Page側で明示したくない場合はhandleInitでBuildContextを渡してしまってもよさそう。
   -> この場合は前提の複数回buildされたときの回避が楽かもしれない

onLoad コールバックをもつようなStatefullWidgetつくって、これをつかって実装すればcontext.readをつかっても大丈夫にできるかもしれない。(しらんけど